### PR TITLE
Mark refreshToken with `@Nullable` in AuthCallback

### DIFF
--- a/app/src/main/java/com/davidmedenjak/redditsample/auth/RedditAuthenticatorService.java
+++ b/app/src/main/java/com/davidmedenjak/redditsample/auth/RedditAuthenticatorService.java
@@ -6,6 +6,7 @@ import android.util.Base64;
 
 import androidx.annotation.NonNull;
 
+import androidx.annotation.Nullable;
 import com.davidmedenjak.auth.AuthCallback;
 import com.davidmedenjak.auth.AuthenticatorService;
 import com.davidmedenjak.auth.TokenPair;
@@ -59,7 +60,7 @@ public class RedditAuthenticatorService extends AuthenticatorService {
         }
 
         @Override
-        public TokenPair authenticate(@NonNull String refreshToken) throws IOException {
+        public TokenPair authenticate(@Nullable String refreshToken) throws IOException {
             String clientId = getBasicAuthForClientId();
             String grantType = "refresh_token";
 

--- a/auth/src/main/java/com/davidmedenjak/auth/AuthCallback.java
+++ b/auth/src/main/java/com/davidmedenjak/auth/AuthCallback.java
@@ -40,6 +40,6 @@ public interface AuthCallback {
      *     error to the listeners.
      * @return the new TokenPair to use for future authentication
      */
-    TokenPair authenticate(@NonNull final String refreshToken)
+    TokenPair authenticate(@Nullable final String refreshToken)
             throws IOException, TokenRefreshError;
 }


### PR DESCRIPTION
When passing in null as refreshToken in TokenPair (which is marked as
`@Nullable`) from AuthCallback, then Kotlin will complain about the
`@NonNull` refreshToken being passed into the authenticate() method.

```
    java.io.IOException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkParameterIsNotNull, parameter refreshToken
        at android.accounts.AccountManager.convertErrorToException(AccountManager.java:2537)
        at android.accounts.AccountManager.access$700(AccountManager.java:162)
        at android.accounts.AccountManager$AmsTask$Response.onError(AccountManager.java:2388)
        at android.accounts.IAccountManagerResponse$Stub.onTransact(IAccountManagerResponse.java:107)
        at android.os.Binder.execTransactInternal(Binder.java:1032)
        at android.os.Binder.execTransact(Binder.java:1005)
```

Fix this by marking the refreshToken parameter as `@Nullable`.