### PR TITLE
Mark refreshToken in TokenPair as `@NonNull`

### DIFF
--- a/auth/src/main/java/com/davidmedenjak/auth/TokenPair.java
+++ b/auth/src/main/java/com/davidmedenjak/auth/TokenPair.java
@@ -1,23 +1,21 @@
 package com.davidmedenjak.auth;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 /** Login credentials for the user. */
 @SuppressWarnings("WeakerAccess")
 public class TokenPair {
 
     @NonNull public final String accessToken;
-    @Nullable public final String refreshToken;
+    @NonNull public final String refreshToken;
 
     /**
      * Create new credentials for the user.
      *
      * @param accessToken used to authenticate the user with the backend
-     * @param refreshToken if set, provides credentials to refresh the access token once it becomes
-     *     invalidated
+     * @param refreshToken credentials to refresh the access token once it becomes invalidated
      */
-    public TokenPair(@NonNull String accessToken, @Nullable String refreshToken) {
+    public TokenPair(@NonNull String accessToken, @NonNull String refreshToken) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
     }


### PR DESCRIPTION
Previously the refreshToken passed in TokenPair (`@Nullable`) was passed
back as `@NonNull` in authenticate() which Kotlin non-null checks didn't
like. If the refresh token really can't be used, then an e.g. empty
string can be used instead. Marking the refreshToken in authenticate()
as `@Nullable` would increase the complexity when the refreshToken is
always non-null.