### PR TITLE
Cancel refresh with `null` refresh token

### DIFF
--- a/app/src/main/java/com/davidmedenjak/redditsample/auth/RedditAuthenticatorService.java
+++ b/app/src/main/java/com/davidmedenjak/redditsample/auth/RedditAuthenticatorService.java
@@ -58,6 +58,7 @@ public class RedditAuthenticatorService extends AuthenticatorService {
             return new Intent(context, LoginActivity.class);
         }
 
+        @NonNull
         @Override
         public TokenPair authenticate(@NonNull String refreshToken) throws IOException {
             String clientId = getBasicAuthForClientId();

--- a/auth/src/main/java/com/davidmedenjak/auth/AuthCallback.java
+++ b/auth/src/main/java/com/davidmedenjak/auth/AuthCallback.java
@@ -40,6 +40,6 @@ public interface AuthCallback {
      *     error to the listeners.
      * @return the new TokenPair to use for future authentication
      */
-    TokenPair authenticate(@NonNull final String refreshToken)
+    @NonNull TokenPair authenticate(@NonNull final String refreshToken)
             throws IOException, TokenRefreshError;
 }

--- a/auth/src/main/java/com/davidmedenjak/auth/OAuthAuthenticator.java
+++ b/auth/src/main/java/com/davidmedenjak/auth/OAuthAuthenticator.java
@@ -233,7 +233,7 @@ public class OAuthAuthenticator extends AbstractAccountAuthenticator {
         void returnResult(AccountAuthenticatorResponse response);
     }
 
-    private class FetchingAuthModel {
+    private static class FetchingAuthModel {
         private boolean fetchingToken = false;
         private List<AccountAuthenticatorResponse> queue;
     }

--- a/auth/src/main/java/com/davidmedenjak/auth/OAuthAuthenticator.java
+++ b/auth/src/main/java/com/davidmedenjak/auth/OAuthAuthenticator.java
@@ -11,6 +11,9 @@ import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -18,9 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 
 import javax.inject.Inject;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 /**
  * A basic implementation of an {@link AbstractAccountAuthenticator} to support OAuth use cases,
@@ -123,7 +123,7 @@ public class OAuthAuthenticator extends AbstractAccountAuthenticator {
             }
 
             final String refreshToken = accountManager.getPassword(account);
-            CallbackListener listener = new CallbackListener(account, authTokenType, service);
+            final CallbackListener listener = new CallbackListener(account, authTokenType, service);
             listener.refresh(refreshToken);
         } else {
             final Bundle resultBundle = createResultBundle(account, authToken);
@@ -250,9 +250,17 @@ public class OAuthAuthenticator extends AbstractAccountAuthenticator {
             this.service = service;
         }
 
-        private void refresh(String refreshToken) {
+        private void refresh(@Nullable String refreshToken) {
+            if (refreshToken == null) {
+                TokenRefreshError error =
+                        new TokenRefreshError(
+                                AccountManager.ERROR_CODE_CANCELED,
+                                "Invalid stored refresh token `null`");
+                onError(error);
+                return;
+            }
             try {
-                TokenPair result = service.authenticate(refreshToken);
+                final TokenPair result = service.authenticate(refreshToken);
                 onAuthenticated(result);
             } catch (IOException e) {
                 onError(TokenRefreshError.NETWORK);
@@ -270,7 +278,8 @@ public class OAuthAuthenticator extends AbstractAccountAuthenticator {
         }
 
         private void onError(@NonNull TokenRefreshError error) {
-            returnResultToQueuedResponses(account, (r) -> r.onError(error.getCode(), error.getErrorMessage()));
+            returnResultToQueuedResponses(
+                    account, (r) -> r.onError(error.getCode(), error.getErrorMessage()));
         }
     }
 }

--- a/auth/src/test/java/com/davidmedenjak/auth/OAuthAuthenticatorTest.java
+++ b/auth/src/test/java/com/davidmedenjak/auth/OAuthAuthenticatorTest.java
@@ -218,6 +218,28 @@ public class OAuthAuthenticatorTest {
         verify(response).onError(errCode, errMessage);
     }
 
+    @Test
+    public void cancelWithNullRefreshToken() throws IOException, TokenRefreshError {
+        am.addAccountExplicitly(account, null, null);
+
+        // `null` password / refresh token
+        am.setPassword(account, null);
+
+        final int errCode = AccountManager.ERROR_CODE_CANCELED;
+
+        withServiceResponse(
+                callback -> {
+                    throw new IllegalStateException("should not run");
+                });
+
+        // when
+        Bundle result = getAuthTokenWithResponse();
+
+        // then
+        assertNull(result);
+        verify(response).onError(eq(errCode), anyString());
+    }
+
     private void withServiceResponse(Function0<TokenPair> action)
             throws TokenRefreshError, IOException {
         withServiceResponse((obj1) -> action.run());


### PR DESCRIPTION
Cancel token refresh when the stored refresh token is `null`. This is an invalid state that should not be able to happen.

Fixes #6